### PR TITLE
feat(providers): use generics to allow for typed providers for more than 5 provider arguments

### DIFF
--- a/packages/pigly/src/_newable.ts
+++ b/packages/pigly/src/_newable.ts
@@ -1,21 +1,3 @@
-export interface Newable0<T> {
-  new(): T;
-}
-export interface Newable1<T, P1> {
-  new(p1: P1): T;
-}
-export interface Newable2<T, P1, P2> {
-  new(p1: P1, p2: P2): T;
-}
-export interface Newable3<T, P1, P2, P3> {
-  new(p1: P1, p2: P2, p3: P3): T;
-}
-export interface Newable4<T, P1, P2, P3, P4> {
-  new(p1: P1, p2: P2, p3: P3, p4: P4): T;
-}
-export interface Newable5<T, P1, P2, P3, P4, P5> {
-  new(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5): T;
-}
-export type Newable<T> = {
-  new(...args: any[]): T;
+export type Newable<T extends new(...args: any[]) => any> = {
+  new(...args: ConstructorParameters<T>): T;
 }

--- a/packages/pigly/src/_provider.ts
+++ b/packages/pigly/src/_provider.ts
@@ -6,5 +6,5 @@ export interface IProvider<T> {
 
 export type ProviderWrap<T> = T extends any[]
   ? {
-    [P in keyof T]: IProvider<T[P]>;
+    [P in keyof T]?: IProvider<T[P]>;
   } : [];

--- a/packages/pigly/src/_provider.ts
+++ b/packages/pigly/src/_provider.ts
@@ -3,3 +3,8 @@ import { IContext } from "./_context";
 export interface IProvider<T> {
   (ctx: IContext): T;
 }
+
+export type ProviderWrap<T> = T extends any[]
+  ? {
+    [P in keyof T]: IProvider<T[P]>;
+  } : [];

--- a/packages/pigly/src/providers/to-class.ts
+++ b/packages/pigly/src/providers/to-class.ts
@@ -1,19 +1,12 @@
-import { IProvider } from "../_provider";
+import { IProvider, ProviderWrap } from "../_provider";
 import { IContext } from "../_context";
-import { Newable0, Newable1, Newable2, Newable3, Newable4, Newable5 } from "../_newable";
-
+import { Newable } from "../_newable";
 
 ///** REQUIRES TRANSFORMER - create a class provider where the constructor arguments are exclusively inferable interface types */
 //export function toClass<T>(): IProvider<T>
 
 /** manually bind a class constructor to argument providers */
-export function toClass<T>(ctor: Newable0<T>): IProvider<T>
-export function toClass<T, P1>(ctor: Newable1<T, P1>, p1: IProvider<P1>): IProvider<T>
-export function toClass<T, P1, P2>(ctor: Newable2<T, P1, P2>, p1: IProvider<P1>, p2: IProvider<P2>): IProvider<T>
-export function toClass<T, P1, P2, P3>(ctor: Newable3<T, P1, P2, P3>, p1: IProvider<P1>, p2: IProvider<P2>, p3: IProvider<P3>): IProvider<T>
-export function toClass<T, P1, P2, P3, P4>(ctor: Newable4<T, P1, P2, P3, P4>, p1: IProvider<P1>, p2: IProvider<P2>, p3: IProvider<P3>, p4: IProvider<P4>): IProvider<T>
-export function toClass<T, P1, P2, P3, P4, P5>(ctor: Newable5<T, P1, P2, P3, P4, P5>, p1: IProvider<P1>, p2: IProvider<P2>, p3: IProvider<P3>, p4: IProvider<P4>, p5: IProvider<P5>): IProvider<T>
-export function toClass(ctor?: any, ...providers: IProvider<any>[]) {
+export function toClass<T extends Newable<any>>(ctor: T, ...providers: ProviderWrap<ConstructorParameters<T>>): IProvider<T> {
   if (ctor === undefined) throw Error('called "toClass" without a Constructor argument');
 
   return (ctx: IContext) => {

--- a/packages/pigly/src/providers/to-self.ts
+++ b/packages/pigly/src/providers/to-self.ts
@@ -1,10 +1,9 @@
 import { Newable } from "../_newable";
-import { IProvider } from "../_provider";
+import { IProvider, ProviderWrap } from "../_provider";
 import { toClass } from "./to-class";
 
 ///** REQUIRES TRANSFORMER - create a class provider where the constructor arguments are inferable */
-export function toSelf<T>(ctor: Newable<T>): IProvider<T>
-export function toSelf<T>(ctor: Newable<T>, ...providers: IProvider<any>[]): IProvider<T>
+export function toSelf<T extends Newable<any>>(ctor: T, ...providers: ProviderWrap<ConstructorParameters<T>>): IProvider<T>
 {
-  return (toClass as any)(ctor, ...providers);
+  return toClass(ctor, ...providers);
 }


### PR DESCRIPTION
I've updated the code to allow the methods `toClass` and `toSelf` to have strict types for providers even if there's more than 5 of them.
This update made it possible to remove all the `Newable0`, `Newable1`, `Newable2`, `Newable3`, `Newable4` and `Newable5` types.

I've also added a type `ProviderWrap` that wraps IProvider around each type in an array. I'm not 100% sure where to put it. So I ended with putting it in `_provider.ts`.

__Update:__ I forgot about the transformer filling the parameters on compile time. So I changed `ProviderWrap` to make the values optional instead.