### PR TITLE
fix(README): fix an issue with a code example missing a quote.

### DIFF
--- a/packages/pigly/README.md
+++ b/packages/pigly/README.md
@@ -132,7 +132,7 @@ kernel.bind(A, toClass(Foo, to(B)))
 a more explicit way to provide a constant
 
 ```ts
-kernel.bind(B, toConst("hello world));
+kernel.bind(B, toConst("hello world"));
 ```
 
 ### asSingleton(provider)


### PR DESCRIPTION
While I was reading through the README. I found a missing quote in one of the code examples.